### PR TITLE
Set ubuntu version to earlier release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
 
     name: Build BCDC-SMK container image
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       dockerversiontag: ${{ steps.calculateImageTag.outputs.DOCKER_VERSION_TAG }}
     steps:

--- a/.github/workflows/devdeploy.yaml
+++ b/.github/workflows/devdeploy.yaml
@@ -13,7 +13,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       dockerversiontag: ${{ steps.retrieveimagetag.outputs.DOCKER_VERSION_TAG }}
       issue_url: ${{ steps.retrieveimagetag.outputs.ISSUE_URL }}

--- a/.github/workflows/prddeploy.yaml
+++ b/.github/workflows/prddeploy.yaml
@@ -27,7 +27,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       dockerversiontag: ${{ steps.retrieveimagetag.outputs.DOCKER_VERSION_TAG }}
 


### PR DESCRIPTION
This addresses an issue we saw with other SMK deploys running in ubuntu-latest. We found that if we specified this release instead of the latest release, the issue did not happen.